### PR TITLE
Ability to use multiple provider files.

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ var bar *pb.ProgressBar
 
 func readFile(file string) []byte {
 	contentByte, err := ioutil.ReadFile(file)
-	errCheck(err)
+	errCheckInfo(err)
 	return contentByte
 }
 
@@ -129,6 +129,12 @@ func errCheck(err error) {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
+	}
+}
+
+func errCheckInfo(err error) {
+	if err != nil {
+		fmt.Println(err)
 	}
 }
 
@@ -170,7 +176,6 @@ func errCheckJSON(err error, data []byte, file string) {
 	if err != nil {
 		err = getDetailedError(err, data)
 		fmt.Printf("Error reading %s: %s\n", file, err)
-		os.Exit(1)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -462,6 +462,7 @@ func checker(URL string, response gorequest.Response, body string, provider Prov
 func readJSON(file string, myProvider *[]Provider) {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
 		fmt.Printf("Provider file %s doesn't exist!\n", file)
+		return
 	}
 
 	contentJson := readFile(file)

--- a/main.go
+++ b/main.go
@@ -454,6 +454,31 @@ func checker(URL string, response gorequest.Response, body string, provider Prov
 	}
 }
 
+func readJSON(file string, myProvider *[]Provider) {
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		fmt.Printf("Provider file %s doesn't exist!\n", file)
+	}
+
+	contentJson := readFile(file)
+	tempProvider := []Provider{}
+	err := json.Unmarshal(contentJson, &tempProvider)
+	errCheckJSON(err, contentJson)
+
+	if len(tempProvider) > 0 {
+		*myProvider = append(*myProvider, tempProvider...)
+	}
+}
+
+func readJSONs(myProvider *[]Provider) {
+	if len(flag.Args()) == 0 {
+		return
+	}
+
+	for _, file := range flag.Args() {
+		readJSON(file, myProvider)
+	}
+}
+
 func main() {
 
 	path := os.Getenv("GOPATH") + "/src/github.com/proabiral/inception/"
@@ -484,14 +509,12 @@ func main() {
 
 	printIfNotSilent("Reading Providers from list at " + ProviderFile)
 
-	contentJson := readFile(ProviderFile)
-
-	err := json.Unmarshal(contentJson, &myProvider)
-	errCheckJSON(err, contentJson)
+	readJSON(ProviderFile, &myProvider)
+	readJSONs(&myProvider)
 
 	validate := validator.New()
 	for i, _ := range myProvider {
-		err = validate.Struct(myProvider[i])
+		err := validate.Struct(myProvider[i])
 		if err != nil {
 			log.Printf("Error on index number %d of given JSON Fingerprint Array", i)
 		}

--- a/main.go
+++ b/main.go
@@ -166,10 +166,10 @@ func getDetailedError(err error, data []byte) error {
 	return err
 }
 
-func errCheckJSON(err error, data []byte) {
+func errCheckJSON(err error, data []byte, file string) {
 	if err != nil {
 		err = getDetailedError(err, data)
-		fmt.Println(err)
+		fmt.Printf("Error reading %s: %s\n", file, err)
 		os.Exit(1)
 	}
 }
@@ -462,7 +462,7 @@ func readJSON(file string, myProvider *[]Provider) {
 	contentJson := readFile(file)
 	tempProvider := []Provider{}
 	err := json.Unmarshal(contentJson, &tempProvider)
-	errCheckJSON(err, contentJson)
+	errCheckJSON(err, contentJson, file)
 
 	if len(tempProvider) > 0 {
 		*myProvider = append(*myProvider, tempProvider...)


### PR DESCRIPTION
This is interesting request (#34), so I've went ahead and implemented it. The only sensible way to do it IMHO is by utilizing `flag.Args()` and because of that the program should be called with `-provider` parameter and additional provider JSONs at the end, like`./inception -d list -provider provider.json provider2.json provider3.json provider4.json`.

I also believe that with multiple files it's better to not crash on read/unmarshalling failure, so I've modified `errCheckJSON` and added `errCheckInfo`, so that `os.Exit(1)` won't be called. But I'm not insisting I'm right here.

It's quite a change and I'm not 100% satisfied with this solution, but at this point I don't see other option.  